### PR TITLE
Allow building with `base-4.16.*`

### DIFF
--- a/lumberjack.cabal
+++ b/lumberjack.cabal
@@ -47,7 +47,7 @@ source-repository head
 library
   hs-source-dirs:    src
   exposed-modules:   Lumberjack
-  build-depends:     base          >= 4.11 && <4.16
+  build-depends:     base          >= 4.11 && <4.17
                    , contravariant >= 1.5 && < 1.6
                    , exceptions    >= 0.10.4 && < 0.11
                    , mtl           >= 2.2.2 && < 2.3


### PR DESCRIPTION
This allows `lumberjack` to build with GHC 9.2.