### PR TITLE
Allow building with `base-4.18.*` (GHC 9.6.*)

### DIFF
--- a/lumberjack.cabal
+++ b/lumberjack.cabal
@@ -50,7 +50,6 @@ library
   build-depends:     base          >= 4.11 && < 4.18
                    , contravariant >= 1.5 && < 1.6
                    , exceptions
-                   , mtl
                    , prettyprinter >= 1.6 && < 1.8
                    , prettyprinter-ansi-terminal >= 1.1.1.2 && < 1.2
                    , text

--- a/lumberjack.cabal
+++ b/lumberjack.cabal
@@ -11,7 +11,7 @@ description:         This is a logging facility.  Yes, there are many, and this 
                      * Logging itself is a monadic activity.  This activity is most often
                        performed in a monad stack with a MonadIO context to allow
                        writing to files.
-                     . 
+                     .
                      * The specific logging action implementations are managed separately
                        from the actions of logging messages in the target code.  This
                        allows logging to be configurable and the manner of logging to
@@ -28,7 +28,7 @@ description:         This is a logging facility.  Yes, there are many, and this 
                        passed and used.
                      .
                      * The prettyprinter package is used for formatting.
-                     
+
 homepage:            https://github.com/GaloisInc/lumberjack
 bug-reports:         https://github.com/GaloisInc/lumberjack/issues
 license:             ISC

--- a/lumberjack.cabal
+++ b/lumberjack.cabal
@@ -47,7 +47,7 @@ source-repository head
 library
   hs-source-dirs:    src
   exposed-modules:   Lumberjack
-  build-depends:     base          >= 4.11 && < 4.18
+  build-depends:     base          >= 4.11 && < 4.19
                    , contravariant >= 1.5 && < 1.6
                    , exceptions
                    , prettyprinter >= 1.6 && < 1.8

--- a/src/Lumberjack.hs
+++ b/src/Lumberjack.hs
@@ -86,9 +86,9 @@ module Lumberjack
   )
 where
 
+import           Control.Monad (when)
 import qualified Control.Monad.Catch as X
 import           Control.Monad.IO.Class
-import           Control.Monad.Reader
 import           Data.Functor.Contravariant
 import           Data.Functor.Contravariant.Divisible
 import           Data.Monoid hiding ( (<>) )


### PR DESCRIPTION
The import from `mtl`'s `Control.Monad.Reader` proves troublesome with `mtl-2.3.*`, which no longer re-exports functionality from `Control.Monad` that `Lumberjack.hs` uses. On the other hand, `Lumberjack.hs` doesn't use anything else from `Control.Monad.Reader`, so the `mtl` dependency can be removed entirely.