### PR TITLE
Allow building with GHC 9.10

### DIFF
--- a/lumberjack.cabal
+++ b/lumberjack.cabal
@@ -47,7 +47,7 @@ source-repository head
 library
   hs-source-dirs:    src
   exposed-modules:   Lumberjack
-  build-depends:     base          >= 4.11 && < 4.20
+  build-depends:     base          >= 4.11 && < 4.21
                    , contravariant >= 1.5 && < 1.6
                    , exceptions
                    , prettyprinter >= 1.6 && < 1.8


### PR DESCRIPTION
All that is required is lifting the upper version bounds on `base`.